### PR TITLE
add awedio crate and new playback tag

### DIFF
--- a/content/crates.toml
+++ b/content/crates.toml
@@ -66,12 +66,17 @@ tags = ["languages", "DSP"]
 [[crates]]
 key = "rodio"
 source = "crates"
-tags = ["MIDI"]
+tags = ["playback"]
 
 [[crates]]
 key = "kira"
 source = "crates"
-tags = ["games"]
+tags = ["games", "playback"]
+
+[[crates]]
+key = "awedio"
+source = "crates"
+tags = ["playback", "embedded"]
 
 [[crates]]
 key = "rubato"


### PR DESCRIPTION
I added awedio is a performant and adaptable playback
library I have been working on.

I removed the MIDI tag from rodio since the crate
does not directly support MIDI and in fact midi
never appears in its API.

I added a new tag "playback" to "rodio", "kira",
and "awedio".

Test by running `zola serve` and verifying expected
results.
